### PR TITLE
Remove libmad VERSION file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ app/src/main/obj/
 app/src/main/libs/
 
 #auto-generated files
+app/.cxx/
+app/release/
 app/src/main/assets/3_TFTD.zip.MD5
 app/src/main/assets/7_translations.zip
 app/src/main/assets/3_TFTD.zip

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,7 @@ if (!buildArchEnv) {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
 
     externalNativeBuild {
         cmake {
@@ -36,8 +35,8 @@ android {
 
     defaultConfig {
         applicationId "org.libsdl.openxcom"
-        minSdkVersion 14
-        targetSdkVersion 25
+        minSdkVersion 10
+        targetSdkVersion 28
 
         externalNativeBuild {
             cmake {
@@ -100,29 +99,41 @@ android {
             zipAlignEnabled true
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    dependenciesInfo {
+        includeInApk true
+        includeInBundle true
+    }
+    buildToolsVersion '30.0.2'
+    ndkVersion '23.1.7779620'
 }
 def getFolder(resource) {
-    def binDir = file('src/main/jni/OpenXcom/bin/' + resource);
-    return binDir;
+    def binDir = file('src/main/jni/OpenXcom/bin/' + resource)
+    return binDir
 }
 task packBin(description: 'Update data files.') {
-    def index = 0;
+    def index = 0
     ['common', 'standard', 'UFO', 'TFTD'].each { String res ->
-        def zip = task("zip" + res, type: Zip)
-        zip.doFirst { println('Packing ' + res + '...') }
-        zip.destinationDir = file('src/main/assets')
-        zip.archiveName = index.toString() + "_" + res + '.zip'
-        zip.from getFolder(res)
-        zip.into res
-        zip.execute()
-        index++;
+        tasks.register('zip' + res, Zip) {
+            doFirst { println('Packing ' + res + '...') }
+            archiveFileName = index.toString() + '_' + res + '.zip'
+            destinationDirectory = file('src/main/assets')
+            from getFolder(res)
+            into res
+        }
+        dependsOn(tasks.getByName('zip' + res))
+        ++index
     }
-    def zipTranslations = task("zipTranslations", type: Zip)
-    zipTranslations.doFirst { println('Packing translations...') }
-    zipTranslations.destinationDir = file('src/main/assets')
-    zipTranslations.archiveName = '7_translations.zip'
-    zipTranslations.from getFolder('translations/output')
-    zipTranslations.execute()
+    tasks.register('zipTranslations', Zip) {
+        doFirst { println('Packing translations...' ) }
+        archiveFileName = '7_translations.zip'
+        destinationDirectory = file('src/main/assets')
+        from getFolder('translations/output')
+    }
+    dependsOn(tasks.getByName('zipTranslations'))
 }
 
 gradle.projectsEvaluated {

--- a/app/src/main/jni/libmad-0.15.1b/VERSION
+++ b/app/src/main/jni/libmad-0.15.1b/VERSION
@@ -1,7 +1,0 @@
-0.15.1b
-configure.ac:24
-version.h:25-28
-msvc++/config.h:99,105,120
-msvc++/mad.h:41-44
-
-Makefile.am:98-100

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.2'
+
+wrapper {
+    gradleVersion = '7.3'
 }
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath 'org.ajoberstar:grgit:1.1.0'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
-        maven {
-            url "https://maven.google.com"
-        }
+        google()
+        mavenCentral()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip


### PR DESCRIPTION
After upgrading to ndk r23b, the libmad VERSION file will conflict with the C++ library header file <version>
as many files have it included.
```
In file included from D:\android\android-sdk\ndk\23.1.7779620\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\c++\v1\cstddef:37:
D:\prj\openxcom-android\app\src\main\jni\libmad-0.15.1b\VERSION:1:1: error: expected unqualified-id
```
The branch is supposed to setup the test environment.